### PR TITLE
made CalibrateTurretCommand (kinda scuffed)

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -56,6 +56,7 @@ public final class Constants {
   public static final class TurretConstants{
     public static final int TURRET_SPARK = 8;
     public static final int HALL_EFFECT_SENSOR_ID = 69;
+    public static final int LIMIT_SWITCH_ID = 1337; //temporary value
   }
   
   public static final class ShooterConstants{

--- a/src/main/java/frc/robot/commands/turret/CalibrateTurretCommand.java
+++ b/src/main/java/frc/robot/commands/turret/CalibrateTurretCommand.java
@@ -1,0 +1,42 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands.turret;
+
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.subsystems.TurretSubsystem;
+
+public class CalibrateTurretCommand extends CommandBase {
+  private TurretSubsystem turretSubsystem;
+
+  public CalibrateTurretCommand(TurretSubsystem turretSubsystem) {
+    this.turretSubsystem = turretSubsystem;
+    addRequirements(turretSubsystem);
+  }
+
+  @Override
+  public void initialize() {
+    turretSubsystem.moveTurret(0.5);
+  }
+
+  @Override
+  public void execute() {
+    if(turretSubsystem.getPhysicalLimit()){
+      turretSubsystem.moveTurret(-0.5);
+    }
+    if(turretSubsystem.getMagLimit()){
+      turretSubsystem.resetEncoder();
+    }
+  }
+
+  @Override
+  public void end(boolean interrupted) {
+    turretSubsystem.stopTurret();
+  }
+
+  @Override
+  public boolean isFinished() {
+    return turretSubsystem.getMagLimit();
+  }
+}

--- a/src/main/java/frc/robot/subsystems/TurretSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/TurretSubsystem.java
@@ -6,7 +6,6 @@ import com.revrobotics.CANSparkMaxLowLevel.MotorType;
 import edu.wpi.first.wpilibj.DigitalInput;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.utils.Limelight;
-import frc.robot.Constants;
 import frc.robot.Constants.CalcConstants;
 import frc.robot.Constants.ShooterConstants;
 import frc.robot.Constants.TurretConstants;
@@ -15,10 +14,14 @@ public class TurretSubsystem extends SubsystemBase {
     public CANSparkMax turretSpark;
     private double distance;
     private DigitalInput hallEffectSensor;
+    private DigitalInput limitSwitch;
+    private double encoderOffset;
 
     public TurretSubsystem() {
         turretSpark = new CANSparkMax(TurretConstants.TURRET_SPARK, MotorType.kBrushless);
         hallEffectSensor = new DigitalInput(TurretConstants.HALL_EFFECT_SENSOR_ID);
+        limitSwitch = new DigitalInput(TurretConstants.LIMIT_SWITCH_ID);
+        encoderOffset = 0.0;
     }
 
     public double calcHoodAngle() {
@@ -35,5 +38,28 @@ public class TurretSubsystem extends SubsystemBase {
 
     public void stopTurret() {
         turretSpark.set(0);
+    }
+
+    /*
+        Couldn't find an actual way to reset SparkMAX, so I found this method on Chief Delphi from the Co-Founder of REV
+        https://www.chiefdelphi.com/t/resetting-encoders-on-spark-max/344485
+
+        Said to save the offset of the current encoder value and subtract it from subsequent reads. Not sure if I implemented it correctly
+        but I tried ;)
+    */
+    public void resetEncoder(){
+        encoderOffset = turretSpark.get();
+    }
+
+    public double getEncoder(){
+        return turretSpark.get() - encoderOffset;
+    }
+
+    public boolean getMagLimit(){
+        return hallEffectSensor.get();
+    }
+
+    public boolean getPhysicalLimit(){
+        return limitSwitch.get();
     }
 }


### PR DESCRIPTION
Attempted to create the CalibrateTurretCommand but not sure if it works

Main concern is the resetEncoder metehod in TurretSubsystem; couldn't find an encoder reset method for the Spark MAX, so I tried to implement [this scuffed solution I found on Chief Delphi](https://www.chiefdelphi.com/t/resetting-encoders-on-spark-max/344485) where you subtract the encoder value at the time when resetEncoder is called from subsequent readings, simulating a zeroed encoder. Not sure if it works or even if the other parts of the command work but here it is 🤡